### PR TITLE
fix: Use correct test for undefined window

### DIFF
--- a/polyfill.js
+++ b/polyfill.js
@@ -5,7 +5,7 @@
 // https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent#Polyfill
 
 (function() {
-  if (!window) {
+  if (typeof window === 'undefined') {
     return;
   }
 


### PR DESCRIPTION
This fixes the server-side usage (silently ignoring instead of blowing up)